### PR TITLE
fix logitechmediaserver.init.d to openrc-run

### DIFF
--- a/media-sound/logitechmediaserver/files/logitechmediaserver.init.d
+++ b/media-sound/logitechmediaserver/files/logitechmediaserver.init.d
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2009 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/media-sound/squeezeboxserver/files/squeezeboxserver.init.d,v 1.1 2009/11/25 22:52:25 lavajoe Exp $


### PR DESCRIPTION
Stops the complaining about QA Notice: #!/sbin/runscript is deprecated, use #!/sbin/openrc-run instead: